### PR TITLE
Update navigation link from Events to Projects

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -25,8 +25,8 @@ const links = [
     link: "/aboutus",
   },
   {
-    title: "Events",
-    link: "/events",
+    title: "Projects",
+    link: "/projects",
   },
   {
     title: "Resources",


### PR DESCRIPTION
Changed the navigation menu item title from 'Events' to 'Projects' and updated its link from '/events' to '/projects' to reflect the new section.